### PR TITLE
Fix the changed hash of the osqp-vendor package

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -126,7 +126,7 @@ let
         rev = "v0.6.2";
         revVariable = "git_tag";
         fetchgitArgs = {
-          hash = "sha256-0BbUe1J9qzvyKDBLTz+pAEmR3QpRL+hnxZ2re/3mEvs=";
+          hash = "sha256-DDO7CCDE2mTi/GSaD9wATxnXHvY9Ndz8WI1oQuEbxeI=";
           leaveDotGit = true;
         };
       })


### PR DESCRIPTION
Fixes the following error:

```
error: hash mismatch in fixed-output derivation '/nix/store/11abdpwg3pjbny9bp880hrlpdm7ipan9-osqp.drv':
         specified: sha256-0BbUe1J9qzvyKDBLTz+pAEmR3QpRL+hnxZ2re/3mEvs=
            got:    sha256-DDO7CCDE2mTi/GSaD9wATxnXHvY9Ndz8WI1oQuEbxeI=
```